### PR TITLE
Update workflows to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ on:
     
 jobs:
   jekyll:
-    runs-on: ubuntu-16.04 # can change this to ubuntu-latest if you prefer
+    runs-on: ubuntu-20.04 # can change this to ubuntu-latest if you prefer
     steps:
       - name: 📂 setup
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ on:
 
 jobs:
   jekyll:
-    runs-on: ubuntu-16.04 # can change this to ubuntu-latest if you prefer
+    runs-on: ubuntu-20.04 # can change this to ubuntu-latest if you prefer
     steps:
       - name: 📂 setup
         uses: actions/checkout@v2


### PR DESCRIPTION
I think CI tests would automatically fail if they were run since currently 16.04 no longer works (both GitHub and Canonical no longer support it), so updated to 20.04 (the latest stable version).